### PR TITLE
logger.cc:142 error: `syscall` was not declared in this scope 

### DIFF
--- a/webcc/logger.cc
+++ b/webcc/logger.cc
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unistd.h>
 
 #if (defined(_WIN32) || defined(_WIN64))
 #include <Windows.h>


### PR DESCRIPTION
logger.cc:142 error: syscall was not declared in this scope fixed for ubuntu 20.x