### PR TITLE
add method to retrieve all message headers

### DIFF
--- a/webcc/message.h
+++ b/webcc/message.h
@@ -45,6 +45,10 @@ public:
     return !headers_.Get(key).empty();
   }
 
+  Headers GetHeaders() const {
+    return headers_;
+  }
+
   std::size_t content_length() const {
     return content_length_;
   }

--- a/webcc/message.h
+++ b/webcc/message.h
@@ -45,7 +45,7 @@ public:
     return !headers_.Get(key).empty();
   }
 
-  Headers GetHeaders() const {
+  const Headers& headers() const {
     return headers_;
   }
 


### PR DESCRIPTION
We need a simple way to access all headers assigned to a HTTP request from the server side.
I think adding this simple getter method to the message.h header should suffice.